### PR TITLE
MP Rest Client 1.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -129,11 +129,18 @@
         <dependency>
             <groupId>com.kumuluz.ee</groupId>
             <artifactId>kumuluzee-json-p-jsonp</artifactId>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.glassfish.jersey.media</groupId>
             <artifactId>jersey-media-json-processing</artifactId>
             <version>${jersey-media.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.glassfish</groupId>
+                    <artifactId>jakarta.json</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <!-- Apache Delta Spike -->
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -38,6 +38,8 @@
         <maven-compiler-plugin.version>3.6.1</maven-compiler-plugin.version>
         <nexus.staging.plugin.version>1.6.8</nexus.staging.plugin.version>
         <gpg.plugin.version>1.6</gpg.plugin.version>
+
+        <unused-url>http://104.18.34.92:1234/null</unused-url>
     </properties>
 
     <scm>
@@ -204,6 +206,11 @@
                     <environmentVariables>
                         <KUMULUZEE_RESTCLIENT_DISABLEJETTYWWWAUTH>true</KUMULUZEE_RESTCLIENT_DISABLEJETTYWWWAUTH>
                     </environmentVariables>
+                    <systemProperties>
+                        <!-- resolved http://microprofile.io:1234/null -->
+                        <!-- if not specified in ip form, Jetty retries all DNS entries and the timeout is incorrect -->
+                        <org.eclipse.microprofile.rest.client.tck.unusedURL>${unused-url}</org.eclipse.microprofile.rest.client.tck.unusedURL>
+                    </systemProperties>
                 </configuration>
             </plugin>
             <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -20,10 +20,12 @@
 
         <jaxb-api.version>2.3.0</jaxb-api.version>
 
-        <kumuluzee.version>3.0.0</kumuluzee.version>
-        <microprofile.rest-client.version>1.1</microprofile.rest-client.version>
+        <kumuluzee.version>3.2.0</kumuluzee.version>
+        <microprofile.rest-client.version>1.2.1</microprofile.rest-client.version>
         <microprofile.config.version>1.3</microprofile.config.version>
+        <microprofile.fault-tolerance.version>1.1.4</microprofile.fault-tolerance.version>
         <deltaspike.version>1.9.0</deltaspike.version>
+        <jersey-media.version>2.28</jersey-media.version>
 
         <kumuluzee.config.version>1.3.0</kumuluzee.config.version>
         <hamcrest.version>1.3</hamcrest.version>
@@ -95,7 +97,11 @@
             <groupId>org.eclipse.microprofile.config</groupId>
             <artifactId>microprofile-config-api</artifactId>
             <version>${microprofile.config.version}</version>
-            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.microprofile.fault-tolerance</groupId>
+            <artifactId>microprofile-fault-tolerance-api</artifactId>
+            <version>${microprofile.fault-tolerance.version}</version>
         </dependency>
         <!-- kumuluzEE -->
         <dependency>
@@ -122,19 +128,12 @@
             <groupId>com.kumuluz.ee</groupId>
             <artifactId>kumuluzee-json-p-jsonp</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.glassfish.jersey.media</groupId>
+            <artifactId>jersey-media-json-processing</artifactId>
+            <version>${jersey-media.version}</version>
+        </dependency>
         <!-- Apache Delta Spike -->
-        <dependency>
-            <groupId>org.apache.deltaspike.core</groupId>
-            <artifactId>deltaspike-core-api</artifactId>
-            <version>${deltaspike.version}</version>
-            <scope>compile</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.deltaspike.core</groupId>
-            <artifactId>deltaspike-core-impl</artifactId>
-            <version>${deltaspike.version}</version>
-            <scope>compile</scope>
-        </dependency>
         <dependency>
             <groupId>org.apache.deltaspike.modules</groupId>
             <artifactId>deltaspike-partial-bean-module-impl</artifactId>

--- a/src/main/java/com/kumuluz/ee/rest/client/mp/MicroprofileRestClientExtension.java
+++ b/src/main/java/com/kumuluz/ee/rest/client/mp/MicroprofileRestClientExtension.java
@@ -22,8 +22,7 @@ package com.kumuluz.ee.rest.client.mp;
 
 import com.kumuluz.ee.common.Extension;
 import com.kumuluz.ee.common.config.EeConfig;
-import com.kumuluz.ee.common.dependencies.EeExtensionDef;
-import com.kumuluz.ee.common.dependencies.EeExtensionGroup;
+import com.kumuluz.ee.common.dependencies.*;
 import com.kumuluz.ee.common.wrapper.KumuluzServerWrapper;
 
 import java.util.Collections;
@@ -37,6 +36,11 @@ import java.util.logging.Logger;
  * @since 1.0.1
  */
 @EeExtensionDef(name = "MicroProfileRestClient", group = EeExtensionGroup.REST_CLIENT)
+@EeComponentDependencies({
+        @EeComponentDependency(EeComponentType.CDI),
+        @EeComponentDependency(EeComponentType.JAX_RS),
+        @EeComponentDependency(EeComponentType.JSON_P)
+})
 public class MicroprofileRestClientExtension implements Extension {
 
     private static final Logger LOG = Logger.getLogger(MicroprofileRestClientExtension.class.getSimpleName());

--- a/src/main/java/com/kumuluz/ee/rest/client/mp/config/RestClientConfigExtension.java
+++ b/src/main/java/com/kumuluz/ee/rest/client/mp/config/RestClientConfigExtension.java
@@ -18,40 +18,43 @@
  *  software. See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-package com.kumuluz.ee.rest.client.mp;
+package com.kumuluz.ee.rest.client.mp.config;
 
-import com.kumuluz.ee.common.Extension;
+import com.kumuluz.ee.common.ConfigExtension;
 import com.kumuluz.ee.common.config.EeConfig;
 import com.kumuluz.ee.common.dependencies.EeExtensionDef;
 import com.kumuluz.ee.common.dependencies.EeExtensionGroup;
 import com.kumuluz.ee.common.wrapper.KumuluzServerWrapper;
+import com.kumuluz.ee.configuration.ConfigurationSource;
 
 import java.util.Collections;
 import java.util.List;
-import java.util.logging.Logger;
 
 /**
- * KumuluzEE {@link Extension} for KumuluzEE Rest Client.
+ * Registers {@link RestClientConfigMapper} configuration source.
  *
- * @author Miha Jamsek
- * @since 1.0.1
+ * @author Urban Malc
+ * @since 1.0.0
  */
-@EeExtensionDef(name = "MicroProfileRestClient", group = EeExtensionGroup.REST_CLIENT)
-public class MicroprofileRestClientExtension implements Extension {
+@EeExtensionDef(name = "RestClientMp", group = EeExtensionGroup.CONFIG)
+public class RestClientConfigExtension implements ConfigExtension {
+    @Override
+    public void load() {
 
-    private static final Logger LOG = Logger.getLogger(MicroprofileRestClientExtension.class.getSimpleName());
+    }
 
     @Override
     public void init(KumuluzServerWrapper server, EeConfig eeConfig) {
-        LOG.info("Initializing MicroProfile Rest Client");
+
     }
 
     @Override
-    public void load() {
+    public ConfigurationSource getConfigurationSource() {
+        return null;
     }
 
     @Override
-    public List<String> scanLibraries() {
-        return Collections.singletonList("kumuluzee-rest-client");
+    public List<ConfigurationSource> getConfigurationSources() {
+        return Collections.singletonList(new RestClientConfigMapper());
     }
 }

--- a/src/main/java/com/kumuluz/ee/rest/client/mp/config/RestClientConfigMapper.java
+++ b/src/main/java/com/kumuluz/ee/rest/client/mp/config/RestClientConfigMapper.java
@@ -1,0 +1,132 @@
+/*
+ *  Copyright (c) 2014-2017 Kumuluz and/or its affiliates
+ *  and other contributors as indicated by the @author tags and
+ *  the contributor list.
+ *
+ *  Licensed under the MIT License (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  https://opensource.org/licenses/MIT
+ *
+ *  The software is provided "AS IS", WITHOUT WARRANTY OF ANY KIND, express or
+ *  implied, including but not limited to the warranties of merchantability,
+ *  fitness for a particular purpose and noninfringement. in no event shall the
+ *  authors or copyright holders be liable for any claim, damages or other
+ *  liability, whether in an action of contract, tort or otherwise, arising from,
+ *  out of or in connection with the software or the use or other dealings in the
+ *  software. See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package com.kumuluz.ee.rest.client.mp.config;
+
+import com.kumuluz.ee.configuration.ConfigurationSource;
+import com.kumuluz.ee.configuration.utils.ConfigurationDispatcher;
+import com.kumuluz.ee.configuration.utils.ConfigurationUtil;
+
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Configuration source that maps MP propagateHeaders key to KumuluzEE key.
+ *
+ * @author Urban Malc
+ * @since 1.2.0
+ */
+public class RestClientConfigMapper implements ConfigurationSource {
+
+    private static final String MP_KEY = "org.eclipse.microprofile.rest.client.propagateHeaders";
+    private static final String KUMULUZ_KEY = "kumuluzee.rest-client.propagate-headers";
+
+    private ConfigurationUtil configurationUtil;
+
+    @Override
+    public void init(ConfigurationDispatcher configurationDispatcher) {
+        configurationUtil = ConfigurationUtil.getInstance();
+    }
+
+    @Override
+    public Optional<String> get(String key) {
+
+        if (key.equals(MP_KEY)) {
+            return configurationUtil.get(KUMULUZ_KEY);
+        }
+
+        return Optional.empty();
+    }
+
+    /**
+     * Low priority so MicroProfile still takes precedence.
+     *
+     * @return configuration source ordinal
+     */
+    @Override
+    public Integer getOrdinal() {
+        return 10;
+    }
+
+    @Override
+    public Optional<Boolean> getBoolean(String key) {
+        return Optional.empty();
+    }
+
+    @Override
+    public Optional<Integer> getInteger(String key) {
+        return Optional.empty();
+    }
+
+    @Override
+    public Optional<Long> getLong(String key) {
+        return Optional.empty();
+    }
+
+    @Override
+    public Optional<Double> getDouble(String key) {
+        return Optional.empty();
+    }
+
+    @Override
+    public Optional<Float> getFloat(String key) {
+        return Optional.empty();
+    }
+
+    @Override
+    public Optional<Integer> getListSize(String key) {
+        return Optional.empty();
+    }
+
+    @Override
+    public Optional<List<String>> getMapKeys(String key) {
+        return Optional.empty();
+    }
+
+    @Override
+    public void watch(String key) {
+
+    }
+
+    @Override
+    public void set(String key, String value) {
+
+    }
+
+    @Override
+    public void set(String key, Boolean value) {
+
+    }
+
+    @Override
+    public void set(String key, Integer value) {
+
+    }
+
+    @Override
+    public void set(String key, Double value) {
+
+    }
+
+    @Override
+    public void set(String key, Float value) {
+
+    }
+}

--- a/src/main/java/com/kumuluz/ee/rest/client/mp/invoker/ParamInfo.java
+++ b/src/main/java/com/kumuluz/ee/rest/client/mp/invoker/ParamInfo.java
@@ -39,7 +39,7 @@ public class ParamInfo {
     private Map<String, Object> pathParameterValues = new HashMap<>();
     private Map<String, Object> queryParameterValues = new HashMap<>();
     private Map<String, Object> cookieParameterValues = new HashMap<>();
-    private MultivaluedMap<String, Object> headerValues = new MultivaluedHashMap<>();
+    private MultivaluedMap<String, String> headerValues = new MultivaluedHashMap<>();
     private Object payload = null;
 
     public void addPathParameter(String name, Object val) {
@@ -54,7 +54,7 @@ public class ParamInfo {
         cookieParameterValues.put(name, val);
     }
 
-    public void addHeader(String name, Object val) {
+    public void addHeader(String name, String val) {
         headerValues.add(name, val);
     }
 
@@ -70,7 +70,7 @@ public class ParamInfo {
         return queryParameterValues;
     }
 
-    public MultivaluedMap<String, Object> getHeaderValues() {
+    public MultivaluedMap<String, String> getHeaderValues() {
         return headerValues;
     }
 

--- a/src/main/java/com/kumuluz/ee/rest/client/mp/providers/CustomJsonValueBodyReader.java
+++ b/src/main/java/com/kumuluz/ee/rest/client/mp/providers/CustomJsonValueBodyReader.java
@@ -18,27 +18,28 @@
  *  software. See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-package com.kumuluz.ee.rest.client.mp.proxy;
+package com.kumuluz.ee.rest.client.mp.providers;
 
-import org.apache.deltaspike.partialbean.impl.PartialBeanProxyFactory;
+import org.glassfish.json.jaxrs.JsonValueBodyReader;
+
+import javax.json.JsonValue;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Type;
 
 /**
- * DeltaSpike proxy factory for interfaces annotated with
- * {@link org.eclipse.microprofile.rest.client.inject.RegisterRestClient}.
+ * {@link javax.ws.rs.ext.MessageBodyReader} for {@link JsonValue} that also accepts default MediaType.
  *
- * @author Miha Jamsek
- * @since 1.0.1
+ * @author Urban Malc
+ * @since 1.2.0
  */
-public class RestClientProxyFactory extends PartialBeanProxyFactory {
+@Produces(MediaType.APPLICATION_JSON)
+public class CustomJsonValueBodyReader extends JsonValueBodyReader {
 
-    /**
-     * We usually check if a class is proxied by checking if its name contains String "$Proxy". This ensures proper
-     * detection across the framework.
-     *
-     * @return proxy class suffix
-     */
     @Override
-    protected String getProxyClassSuffix() {
-        return "$$ProxyDSPartialBean";
+    public boolean isReadable(Class<?> aClass, Type type, Annotation[] annotations, MediaType mediaType) {
+        return JsonValue.class.isAssignableFrom(aClass) && mediaType == MediaType.APPLICATION_OCTET_STREAM_TYPE ||
+                super.isReadable(aClass, type, annotations, mediaType);
     }
 }

--- a/src/main/java/com/kumuluz/ee/rest/client/mp/providers/CustomJsonValueBodyWriter.java
+++ b/src/main/java/com/kumuluz/ee/rest/client/mp/providers/CustomJsonValueBodyWriter.java
@@ -18,27 +18,28 @@
  *  software. See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-package com.kumuluz.ee.rest.client.mp.proxy;
+package com.kumuluz.ee.rest.client.mp.providers;
 
-import org.apache.deltaspike.partialbean.impl.PartialBeanProxyFactory;
+import org.glassfish.json.jaxrs.JsonValueBodyWriter;
+
+import javax.json.JsonValue;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Type;
 
 /**
- * DeltaSpike proxy factory for interfaces annotated with
- * {@link org.eclipse.microprofile.rest.client.inject.RegisterRestClient}.
+ * {@link javax.ws.rs.ext.MessageBodyWriter} for {@link JsonValue} that also accepts default MediaType.
  *
- * @author Miha Jamsek
- * @since 1.0.1
+ * @author Urban Malc
+ * @since 1.2.0
  */
-public class RestClientProxyFactory extends PartialBeanProxyFactory {
+@Produces(MediaType.APPLICATION_JSON)
+public class CustomJsonValueBodyWriter extends JsonValueBodyWriter {
 
-    /**
-     * We usually check if a class is proxied by checking if its name contains String "$Proxy". This ensures proper
-     * detection across the framework.
-     *
-     * @return proxy class suffix
-     */
     @Override
-    protected String getProxyClassSuffix() {
-        return "$$ProxyDSPartialBean";
+    public boolean isWriteable(Class<?> aClass, Type type, Annotation[] annotations, MediaType mediaType) {
+        return JsonValue.class.isAssignableFrom(aClass) && mediaType == null ||
+                super.isWriteable(aClass, type, annotations, mediaType);
     }
 }

--- a/src/main/java/com/kumuluz/ee/rest/client/mp/providers/IncomingHeadersInterceptor.java
+++ b/src/main/java/com/kumuluz/ee/rest/client/mp/providers/IncomingHeadersInterceptor.java
@@ -1,0 +1,28 @@
+package com.kumuluz.ee.rest.client.mp.providers;
+
+import javax.annotation.Priority;
+import javax.enterprise.context.RequestScoped;
+import javax.ws.rs.Priorities;
+import javax.ws.rs.container.ContainerRequestContext;
+import javax.ws.rs.container.ContainerRequestFilter;
+import javax.ws.rs.core.MultivaluedHashMap;
+import javax.ws.rs.core.MultivaluedMap;
+import javax.ws.rs.ext.Provider;
+import java.io.IOException;
+
+@Provider
+@Priority(Priorities.USER + 5000)
+@RequestScoped
+public class IncomingHeadersInterceptor implements ContainerRequestFilter {
+
+    private MultivaluedMap<String, String> incomingHeaders = new MultivaluedHashMap<>();
+
+    public MultivaluedMap<String, String> getIncomingHeaders() {
+        return incomingHeaders;
+    }
+
+    @Override
+    public void filter(ContainerRequestContext requestContext) throws IOException {
+        requestContext.getHeaders().forEach((k, v) -> this.incomingHeaders.addAll(k, v));
+    }
+}

--- a/src/main/java/com/kumuluz/ee/rest/client/mp/spec/RestClientBuilderImpl.java
+++ b/src/main/java/com/kumuluz/ee/rest/client/mp/spec/RestClientBuilderImpl.java
@@ -32,6 +32,7 @@ import org.eclipse.microprofile.rest.client.ext.AsyncInvocationInterceptorFactor
 import org.eclipse.microprofile.rest.client.ext.ResponseExceptionMapper;
 import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
 import org.eclipse.microprofile.rest.client.spi.RestClientListener;
+import org.glassfish.jersey.jetty.connector.JettyClientProperties;
 import org.glassfish.jersey.jetty.connector.JettyConnectorProvider;
 
 import javax.annotation.Priority;
@@ -200,6 +201,11 @@ public class RestClientBuilderImpl implements RestClientBuilder {
 
         if (!MapperDisabledUtil.isMapperDisabled(this.clientBuilder)) {
             register(DefaultExceptionMapper.class);
+        }
+
+        if (ConfigurationUtil.getInstance().getBoolean("kumuluzee.rest-client.enable-ssl-hostname-verification")
+                .orElse(true)) {
+            clientBuilder.property(JettyClientProperties.ENABLE_SSL_HOSTNAME_VERIFICATION, true);
         }
 
         Client client = clientBuilder.build();

--- a/src/main/java/com/kumuluz/ee/rest/client/mp/spec/RestClientBuilderImpl.java
+++ b/src/main/java/com/kumuluz/ee/rest/client/mp/spec/RestClientBuilderImpl.java
@@ -190,11 +190,10 @@ public class RestClientBuilderImpl implements RestClientBuilder {
             }
         }
         if (this.connectTimeoutUnit != null) {
-            this.clientBuilder.connectTimeout(TimeUnit.MILLISECONDS.convert(connectTimeout, connectTimeoutUnit) / 4,
-                    TimeUnit.MILLISECONDS);
+            this.clientBuilder.connectTimeout(this.connectTimeout, this.connectTimeoutUnit);
         }
         if (this.readTimeoutUnit != null) {
-            this.clientBuilder.readTimeout(readTimeout, readTimeoutUnit);
+            this.clientBuilder.readTimeout(this.readTimeout, this.readTimeoutUnit);
         }
 
         ProviderRegistrationUtil.registerProviders(clientBuilder, apiClass);

--- a/src/main/java/com/kumuluz/ee/rest/client/mp/util/BeanParamProcessorUtil.java
+++ b/src/main/java/com/kumuluz/ee/rest/client/mp/util/BeanParamProcessorUtil.java
@@ -58,7 +58,7 @@ public class BeanParamProcessorUtil {
                 if (field.isAnnotationPresent(HeaderParam.class)) {
                     HeaderParam headerParam = field.getAnnotation(HeaderParam.class);
                     field.setAccessible(true);
-                    paramInfo.addHeader(headerParam.value(), field.get(instance));
+                    paramInfo.addHeader(headerParam.value(), (String) field.get(instance));
                 }
                 if (field.isAnnotationPresent(CookieParam.class)) {
                     CookieParam cookieParam = field.getAnnotation(CookieParam.class);

--- a/src/main/java/com/kumuluz/ee/rest/client/mp/util/ClientHeaderParamUtil.java
+++ b/src/main/java/com/kumuluz/ee/rest/client/mp/util/ClientHeaderParamUtil.java
@@ -1,0 +1,249 @@
+/*
+ *  Copyright (c) 2014-2017 Kumuluz and/or its affiliates
+ *  and other contributors as indicated by the @author tags and
+ *  the contributor list.
+ *
+ *  Licensed under the MIT License (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  https://opensource.org/licenses/MIT
+ *
+ *  The software is provided "AS IS", WITHOUT WARRANTY OF ANY KIND, express or
+ *  implied, including but not limited to the warranties of merchantability,
+ *  fitness for a particular purpose and noninfringement. in no event shall the
+ *  authors or copyright holders be liable for any claim, damages or other
+ *  liability, whether in an action of contract, tort or otherwise, arising from,
+ *  out of or in connection with the software or the use or other dealings in the
+ *  software. See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package com.kumuluz.ee.rest.client.mp.util;
+
+import org.eclipse.microprofile.rest.client.RestClientDefinitionException;
+import org.eclipse.microprofile.rest.client.annotation.ClientHeaderParam;
+
+import javax.ws.rs.core.MultivaluedHashMap;
+import javax.ws.rs.core.MultivaluedMap;
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Method;
+import java.lang.reflect.Proxy;
+import java.util.*;
+
+/**
+ * Utility methods for processing and validating {@link ClientHeaderParam} annotations.
+ *
+ * @author Urban Malc
+ * @since 1.2.0
+ */
+public class ClientHeaderParamUtil {
+
+    public static MultivaluedMap<String, String> collectClientHeaderParams(Method method) throws Throwable {
+        MultivaluedMap<String, String> interfaceHeaders = new MultivaluedHashMap<>();
+        for (ClientHeaderParam clientHeaderParam : method.getDeclaringClass().getAnnotationsByType(ClientHeaderParam.class)) {
+            processClientHeaderParam(interfaceHeaders, clientHeaderParam, method);
+        }
+        MultivaluedMap<String, String> methodHeaders = new MultivaluedHashMap<>();
+        for (ClientHeaderParam clientHeaderParam : method.getAnnotationsByType(ClientHeaderParam.class)) {
+            processClientHeaderParam(methodHeaders, clientHeaderParam, method);
+        }
+
+        methodHeaders.forEach((k, v) -> {
+            interfaceHeaders.remove(k);
+            interfaceHeaders.addAll(k, v);
+        });
+
+        return interfaceHeaders;
+    }
+
+    private static void processClientHeaderParam(MultivaluedMap<String, String> headers,
+                                                 ClientHeaderParam clientHeaderParam, Method method) throws Throwable {
+        if (clientHeaderParam.value().length == 1 && isMethodCall(clientHeaderParam.value()[0])) {
+            processMethodClientHeaderParam(headers, clientHeaderParam, method);
+            return;
+        }
+
+        List<String> paramValues = new ArrayList<>();
+        for (String value : clientHeaderParam.value()) {
+            if (isMethodCall(value)) {
+                throw new RestClientDefinitionException("Multiple method references defined in single ClientHeaderParam");
+            }
+
+            paramValues.add(value);
+        }
+
+        addToHeaderMap(clientHeaderParam.name(), paramValues, headers);
+    }
+
+    private static void processMethodClientHeaderParam(MultivaluedMap<String, String> headers,
+                                                       ClientHeaderParam clientHeaderParam, Method method) throws Throwable {
+        try {
+            String invocationName = clientHeaderParam.value()[0];
+            invocationName = invocationName.substring(1, invocationName.length() - 1);
+
+            int separatorIdx = invocationName.lastIndexOf(".");
+
+            Class<?> invocationClass = method.getDeclaringClass();
+            String invocationMethod = invocationName;
+            if (separatorIdx >= 0) {
+                invocationClass = Class.forName(invocationName.substring(0, separatorIdx));
+                invocationMethod = invocationName.substring(separatorIdx + 1);
+            }
+
+            Object returnObject = null;
+            for (Method m : invocationClass.getMethods()) {
+                if (m.getName().equals(invocationMethod)) {
+                    if (m.getParameterCount() == 0) {
+                        if (separatorIdx < 0) {
+                            returnObject = invokeDefaultMethod(method.getDeclaringClass(), m, null);
+                        } else {
+                            returnObject = m.invoke(null);
+                        }
+                    } else if (m.getParameterCount() == 1) {
+                        if (m.getParameterTypes()[0].isAssignableFrom(String.class)) {
+                            if (separatorIdx < 0) {
+                                returnObject = invokeDefaultMethod(method.getDeclaringClass(), m, clientHeaderParam.name());
+                            } else {
+                                returnObject = m.invoke(null, clientHeaderParam.name());
+                            }
+                        }
+                    }
+                }
+            }
+
+            if (returnObject == null) {
+                throw new IllegalArgumentException("Method reference not found or returned null");
+            }
+
+            if (returnObject instanceof String) {
+                addToHeaderMap(clientHeaderParam.name(), Collections.singletonList((String)returnObject), headers);
+            } else if (returnObject instanceof String[]) {
+                addToHeaderMap(clientHeaderParam.name(), Arrays.asList((String[])returnObject), headers);
+            } else {
+                throw new IllegalArgumentException("Method returned object that is neither String or String[]");
+            }
+        } catch (RestClientDefinitionException e) {
+            throw e;
+        } catch (Throwable e) {
+            if (clientHeaderParam.required()) {
+                throw e;
+            }
+        }
+    }
+
+    private static Object invokeDefaultMethod(Class interfaceClass, Method method, String argument) throws Throwable {
+
+        final Constructor<MethodHandles.Lookup> constructor = MethodHandles.Lookup.class.getDeclaredConstructor(Class.class, int.class);
+        if (!constructor.isAccessible()) {
+            constructor.setAccessible(true);
+        }
+
+        Object proxyInstance = Proxy.newProxyInstance(Thread.currentThread().getContextClassLoader(),
+                new Class[]{interfaceClass},
+                (Object proxy, Method m, Object[] arguments) -> null);
+
+        MethodHandle handle = constructor.newInstance(interfaceClass, MethodHandles.Lookup.PRIVATE)
+                .unreflectSpecial(method, method.getDeclaringClass())
+                .bindTo(proxyInstance);
+
+        if (argument == null) {
+            return handle.invokeWithArguments();
+        } else {
+            return handle.invokeWithArguments(argument);
+        }
+    }
+
+    private static void addToHeaderMap(String name, List<String> paramValues, MultivaluedMap<String, String> headers) {
+        if (headers.containsKey(name)) {
+            throw new RestClientDefinitionException("Multiple values defined for the same header on the same target");
+        }
+
+        headers.addAll(name, paramValues);
+    }
+
+    private static boolean isMethodCall(String value) {
+        return value.startsWith("{") && value.endsWith("}");
+    }
+
+    public static void validateClientHeaderParams(Method method) {
+        Set<String> definedNames = new HashSet<>();
+        for (ClientHeaderParam clientHeaderParam : method.getDeclaringClass().getAnnotationsByType(ClientHeaderParam.class)) {
+            if (definedNames.contains(clientHeaderParam.name())) {
+                throw new RestClientDefinitionException(getHumanFriendlyDescriptor(method) +
+                        " Interface class defines multiple ClientHeaderParams with the name " +
+                        clientHeaderParam.name());
+            } else {
+                definedNames.add(clientHeaderParam.name());
+            }
+            validateClientHeaderParam(clientHeaderParam, method);
+        }
+        definedNames.clear();
+        for (ClientHeaderParam clientHeaderParam : method.getAnnotationsByType(ClientHeaderParam.class)) {
+            if (definedNames.contains(clientHeaderParam.name())) {
+                throw new RestClientDefinitionException(getHumanFriendlyDescriptor(method) +
+                        " Method defines multiple ClientHeaderParams with the name " +
+                        clientHeaderParam.name());
+            } else {
+                definedNames.add(clientHeaderParam.name());
+            }
+            validateClientHeaderParam(clientHeaderParam, method);
+        }
+    }
+
+    private static void validateClientHeaderParam(ClientHeaderParam clientHeaderParam, Method method) {
+        long methodCalls = Arrays.stream(clientHeaderParam.value()).filter(ClientHeaderParamUtil::isMethodCall).count();
+        if (methodCalls >= 1 && clientHeaderParam.value().length > 1) {
+            throw new RestClientDefinitionException(getHumanFriendlyDescriptor(method) +
+                    " Additional values defined alongside method reference in single ClientHeaderParam");
+        }
+
+        Arrays.stream(clientHeaderParam.value()).filter(ClientHeaderParamUtil::isMethodCall).forEach(ref -> {
+            String invocationName = ref.substring(1, ref.length() - 1);
+            int separatorIdx = invocationName.lastIndexOf(".");
+
+            Class<?> invocationClass = method.getDeclaringClass();
+            String invocationMethod = invocationName;
+            if (separatorIdx >= 0) {
+                try {
+                    invocationClass = Class.forName(invocationName.substring(0, separatorIdx));
+                } catch (ClassNotFoundException e) {
+                    throw new RestClientDefinitionException(getHumanFriendlyDescriptor(method) +
+                            " Could not resolve class declared in method reference: " +
+                            invocationName.substring(0, separatorIdx));
+                }
+                invocationMethod = invocationName.substring(separatorIdx + 1);
+            }
+
+            Method matchingMethod = null;
+            for (Method m : invocationClass.getMethods()) {
+                if (m.getName().equals(invocationMethod)) {
+                    if (m.getParameterCount() == 0) {
+                        matchingMethod = m;
+                    } else if (m.getParameterCount() == 1) {
+                        if (m.getParameterTypes()[0].isAssignableFrom(String.class)) {
+                            matchingMethod = m;
+                        }
+                    }
+                }
+            }
+
+            if (matchingMethod == null) {
+                throw new RestClientDefinitionException(getHumanFriendlyDescriptor(method) +
+                        " Could not find method reference. Make sure it has either zero parameters or one parameter " +
+                        "of type String.");
+            }
+
+            if (!matchingMethod.getReturnType().isAssignableFrom(String.class) &&
+                    !matchingMethod.getReturnType().isAssignableFrom(String[].class)) {
+                throw new RestClientDefinitionException(getHumanFriendlyDescriptor(method) +
+                        " Method reference should return either String or String[].");
+            }
+        });
+    }
+
+    private static String getHumanFriendlyDescriptor(Method method) {
+        return String.format("[Method: %s; Class: %s]", method.getName(), method.getDeclaringClass().getName());
+    }
+}

--- a/src/main/java/com/kumuluz/ee/rest/client/mp/util/InterfaceValidatorUtil.java
+++ b/src/main/java/com/kumuluz/ee/rest/client/mp/util/InterfaceValidatorUtil.java
@@ -55,6 +55,10 @@ public class InterfaceValidatorUtil {
     public static <T> void validateApiInterface(Class<T> apiClass) {
         checkForMultipleHttpMethods(apiClass.getMethods());
         checkForMatchingParams(apiClass);
+
+        for (Method m : apiClass.getMethods()) {
+            ClientHeaderParamUtil.validateClientHeaderParams(m);
+        }
     }
 
     private static <T> void checkForMatchingParams(Class<T> apiClass) {

--- a/src/main/java/com/kumuluz/ee/rest/client/mp/util/ProviderRegistrationUtil.java
+++ b/src/main/java/com/kumuluz/ee/rest/client/mp/util/ProviderRegistrationUtil.java
@@ -55,13 +55,13 @@ public class ProviderRegistrationUtil {
 
         // mp config providers
         Optional<String> definedProviders = RegistrationConfigUtil.getConfigurationParameter(interfaceType,
-                "providers", String.class);
+                "providers", String.class, true);
         if (definedProviders.isPresent()) {
             String[] providerNames = definedProviders.get().split(",");
 
             for (String providerName : providerNames) {
                 Optional<Integer> providerPriority = RegistrationConfigUtil.getConfigurationParameter(interfaceType,
-                        "providers/" + providerName + "/priority", Integer.class);
+                        "providers/" + providerName + "/priority", Integer.class, false);
                 try {
                     if (providerPriority.isPresent()) {
                         clientBuilder.register(Class.forName(providerName), providerPriority.get());

--- a/src/main/java/com/kumuluz/ee/rest/client/mp/util/RegistrationConfigUtil.java
+++ b/src/main/java/com/kumuluz/ee/rest/client/mp/util/RegistrationConfigUtil.java
@@ -57,7 +57,8 @@ public class RegistrationConfigUtil {
         }
     }
 
-    public static <T> Optional<T> getConfigurationParameter(Class<?> registration, String property, Class<T> tClass) {
+    public static <T> Optional<T> getConfigurationParameter(Class<?> registration, String property, Class<T> tClass,
+                                                            boolean useSnakeCase) {
         if (registrationToIndex == null) {
             scanRegistrations();
         }
@@ -67,7 +68,8 @@ public class RegistrationConfigUtil {
         keys.add(classname + "/mp-rest/" + property);
 
         if (registrationToIndex.containsKey(classname)) {
-            keys.add("kumuluzee.rest-client.registrations[" + registrationToIndex.get(classname) + "]." + property);
+            keys.add("kumuluzee.rest-client.registrations[" + registrationToIndex.get(classname) + "]." +
+                    ((useSnakeCase) ? toSnakeCase(property) : property));
         }
 
         Optional<T> param = Optional.empty();
@@ -90,6 +92,8 @@ public class RegistrationConfigUtil {
             return (Optional<T>) configurationUtil.get(key);
         } else if (tClass.equals(Integer.class)) {
             return (Optional<T>) configurationUtil.getInteger(key);
+        } else if (tClass.equals(Long.class)) {
+            return (Optional<T>) configurationUtil.getLong(key);
         } else if (tClass.equals(URL.class)) {
             String url = configurationUtil.get(key).orElse(null);
             if (url == null) {
@@ -109,5 +113,19 @@ public class RegistrationConfigUtil {
         } else {
             throw new IllegalArgumentException("Converter for " + tClass + " not found.");
         }
+    }
+
+    private static String toSnakeCase(String s) {
+        StringBuilder sb = new StringBuilder();
+
+        for (char c : s.toCharArray()) {
+            if (Character.isUpperCase(c)) {
+                sb.append("-").append(Character.toLowerCase(c));
+            } else {
+                sb.append(c);
+            }
+        }
+
+        return sb.toString();
     }
 }

--- a/src/main/resources/META-INF/services/com.kumuluz.ee.common.ConfigExtension
+++ b/src/main/resources/META-INF/services/com.kumuluz.ee.common.ConfigExtension
@@ -1,0 +1,1 @@
+com.kumuluz.ee.rest.client.mp.config.RestClientConfigExtension

--- a/src/test/java/com/kumuluz/ee/rest/client/mp/DependencyAppender.java
+++ b/src/test/java/com/kumuluz/ee/rest/client/mp/DependencyAppender.java
@@ -43,21 +43,20 @@ public class DependencyAppender implements MavenDependencyAppender {
 
         libs.add("com.kumuluz.ee:kumuluzee-jax-rs-jersey:");
         libs.add("com.kumuluz.ee:kumuluzee-json-p-jsonp:");
+        libs.add("org.glassfish.jersey.media:jersey-media-json-processing:" +
+                versionsBundle.getString("jersey-media-version"));
         libs.add("com.kumuluz.ee.config:kumuluzee-config-mp:" +
                 versionsBundle.getString("kumuluzee-config-mp-version"));
 
         libs.add("org.eclipse.microprofile.rest.client:microprofile-rest-client-api:" +
                 versionsBundle.getString("microprofile-rest-client-version"));
+        libs.add("org.eclipse.microprofile.fault-tolerance:microprofile-fault-tolerance-api:" +
+                versionsBundle.getString("microprofile-fault-tolerance-version"));
 
         libs.add("org.hamcrest:hamcrest-all:" + versionsBundle.getString("hamcrest-version"));
 
-        final String DELTA_SPIKE_VERSION = versionsBundle.getString("deltaspike-version");
-        libs.add("org.apache.deltaspike.core:deltaspike-core-api:" +
-                DELTA_SPIKE_VERSION);
-        libs.add("org.apache.deltaspike.core:deltaspike-core-impl:" +
-                DELTA_SPIKE_VERSION);
         libs.add("org.apache.deltaspike.modules:deltaspike-partial-bean-module-impl:" +
-                DELTA_SPIKE_VERSION);
+                versionsBundle.getString("deltaspike-version"));
 
         return libs;
     }

--- a/src/test/java/com/kumuluz/ee/rest/client/mp/RestClientLibraryAppender.java
+++ b/src/test/java/com/kumuluz/ee/rest/client/mp/RestClientLibraryAppender.java
@@ -21,6 +21,7 @@
 package com.kumuluz.ee.rest.client.mp;
 
 import com.kumuluz.ee.rest.client.mp.cdi.RestClientExtension;
+import com.kumuluz.ee.rest.client.mp.config.RestClientConfigExtension;
 import com.kumuluz.ee.rest.client.mp.spec.ClientBuilderResolver;
 import org.jboss.arquillian.container.test.spi.client.deployment.CachedAuxilliaryArchiveAppender;
 import org.jboss.shrinkwrap.api.Archive;
@@ -38,9 +39,10 @@ public class RestClientLibraryAppender extends CachedAuxilliaryArchiveAppender {
     @Override
     protected Archive<?> buildArchive() {
 
-        return ShrinkWrap.create(JavaArchive.class, "kumuluzee-rest-client-mp.jar")
+        return ShrinkWrap.create(JavaArchive.class, "kumuluzee-rest-client-0.0.0.jar")
                 .addPackages(true, MicroprofileRestClientExtension.class.getPackage())
                 .addAsServiceProvider(com.kumuluz.ee.common.Extension.class, MicroprofileRestClientExtension.class)
+                .addAsServiceProvider(com.kumuluz.ee.common.ConfigExtension.class, RestClientConfigExtension.class)
                 .addAsServiceProvider(javax.enterprise.inject.spi.Extension.class, RestClientExtension.class)
                 .addAsServiceProvider(org.eclipse.microprofile.rest.client.spi.RestClientBuilderResolver.class,
                         ClientBuilderResolver.class)

--- a/src/test/resources/META-INF/kumuluzee/rest-client/versions.properties
+++ b/src/test/resources/META-INF/kumuluzee/rest-client/versions.properties
@@ -2,3 +2,5 @@ microprofile-rest-client-version=${microprofile.rest-client.version}
 kumuluzee-config-mp-version=${kumuluzee.config.version}
 hamcrest-version=${hamcrest.version}
 deltaspike-version=${deltaspike.version}
+jersey-media-version=${jersey-media.version}
+microprofile-fault-tolerance-version=${microprofile.fault-tolerance.version}

--- a/src/test/resources/arquillian.xml
+++ b/src/test/resources/arquillian.xml
@@ -5,6 +5,8 @@
     <container qualifier="KumuluzEE" default="true">
         <configuration>
             <!--<property name="javaArguments">-Xmx512m -XX:MaxPermSize=128m -Xrunjdwp:transport=dt_socket,address=8787,server=y,suspend=y</property>-->
+            <!-- see comment in surefire configuration -->
+            <property name="javaArguments">-Dorg.eclipse.microprofile.rest.client.tck.unusedURL=${unused-url}</property>
         </configuration>
     </container>
 </arquillian>

--- a/tck-suite.xml
+++ b/tck-suite.xml
@@ -6,9 +6,29 @@
             <package name="org.eclipse.microprofile.rest.client.tck.*"/>
         </packages>
         <classes>
-            <class name="org.eclipse.microprofile.rest.client.tck.asynctests.AsyncMethodTest">
+            <class name="org.eclipse.microprofile.rest.client.tck.InvokeWithRegisteredProvidersTest">
                 <methods>
-                    <exclude name="testAsyncInvocationInterceptorProvider"/> <!-- fixed in MP 1.2 spec -->
+                    <exclude name=".*"/>
+                </methods>
+            </class>
+            <class name="org.eclipse.microprofile.rest.client.tck.InvokeWithBuiltProvidersTest">
+                <methods>
+                    <exclude name=".*"/>
+                </methods>
+            </class>
+            <class name="org.eclipse.microprofile.rest.client.tck.cditests.CDIInvokeWithRegisteredProvidersTest">
+                <methods>
+                    <exclude name=".*"/>
+                </methods>
+            </class>
+            <class name="org.eclipse.microprofile.rest.client.tck.ClientHeadersFactoryTest">
+                <methods>
+                    <exclude name="testClientHeadersFactoryInvoked"/>
+                </methods>
+            </class>
+            <class name="org.eclipse.microprofile.rest.client.tck.ClientHeaderParamTest">
+                <methods>
+                    <exclude name="testHeaderNotSentWhenExceptionThrownAndRequiredIsFalse"/>
                 </methods>
             </class>
         </classes>


### PR DESCRIPTION
#### Changes

- Added read/connect timeout
- Read URI from `@RegisterRestClient` annotation
- added removeContext() to AsyncInterceptors
- Added RestClientListener support
- `@Consumes` and `@Produces` annotations add _Accept_ and _Content-Type_ headers.
- Properly forward JSON parsing exceptions
- `@ClientHeaderParam` support
- `ClientHeadersFactory` support
- Propagate incoming headers
- Proper integration with JSON-P
- Use dynamic proxy instead of DeltaSpike proxy when not using CDI
- Enabled SSL hostname verification by default
- Added EE Component dependency information

#### Tests

The following tests are disabled because of [microprofile-rest-client/#164](https://github.com/eclipse/microprofile-rest-client/issues/164):

- `ClientHeaderParamTest#testHeaderNotSentWhenExceptionThrownAndRequiredIsFalse`
- `ClientHeadersFactoryTest#testClientHeadersFactoryInvoked`

The following tests are disabled because of [microprofile-rest-client/#165](https://github.com/eclipse/microprofile-rest-client/issues/165):

- `InvokeWithRegisteredProvidersTest`
- `CDIInvokeWithRegisteredProvidersTest`
- `InvokeWithBuiltProvidersTest`
