### PR TITLE
raised mp-rest-client to v1.4.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,8 +20,8 @@
 
         <jaxb-api.version>2.3.0</jaxb-api.version>
 
-        <kumuluzee.version>3.5.0</kumuluzee.version>
-        <microprofile.rest-client.version>1.3.3</microprofile.rest-client.version>
+        <kumuluzee.version>3.7.0</kumuluzee.version>
+        <microprofile.rest-client.version>1.4.0</microprofile.rest-client.version>
         <microprofile.config.version>1.3</microprofile.config.version>
         <microprofile.fault-tolerance.version>1.1.4</microprofile.fault-tolerance.version>
         <jersey-media.version>2.28</jersey-media.version>

--- a/src/main/java/com/kumuluz/ee/rest/client/mp/util/ClientHeaderParamUtil.java
+++ b/src/main/java/com/kumuluz/ee/rest/client/mp/util/ClientHeaderParamUtil.java
@@ -27,9 +27,7 @@ import javax.ws.rs.core.MultivaluedHashMap;
 import javax.ws.rs.core.MultivaluedMap;
 import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodHandles;
-import java.lang.reflect.Constructor;
-import java.lang.reflect.Method;
-import java.lang.reflect.Proxy;
+import java.lang.reflect.*;
 import java.util.*;
 
 /**
@@ -143,10 +141,15 @@ public class ClientHeaderParamUtil {
         Object proxyInstance = Proxy.newProxyInstance(Thread.currentThread().getContextClassLoader(),
                 new Class[]{interfaceClass},
                 (Object proxy, Method m, Object[] arguments) -> null);
-
-        MethodHandle handle = constructor.newInstance(interfaceClass, MethodHandles.Lookup.PRIVATE)
-                .unreflectSpecial(method, method.getDeclaringClass())
-                .bindTo(proxyInstance);
+    
+        
+        Field field = MethodHandles.Lookup.class.getDeclaredField("IMPL_LOOKUP");
+        field.setAccessible(true);
+        MethodHandles.Lookup lookup = (MethodHandles.Lookup) field.get(null);
+        Class<?> declaringClazz = method.getDeclaringClass();
+        
+        MethodHandle handle = lookup.unreflectSpecial(method, declaringClazz)
+        .bindTo(proxyInstance);
 
         if (argument == null) {
             return handle.invokeWithArguments();


### PR DESCRIPTION
Raised MP Rest client to v1.4.0
- Ensured CDI context in ClientHeadersFactory
- Fix for MethodHandle to handle interface's default methods