### PR TITLE
Made JSON-B dependency optional

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -133,11 +133,6 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>com.kumuluz.ee</groupId>
-            <artifactId>kumuluzee-json-b-yasson</artifactId>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
             <groupId>com.kumuluz.ee.rest</groupId>
             <artifactId>kumuluzee-rest-core</artifactId>
             <version>${kumuluzee.rest.version}</version>

--- a/src/main/java/com/kumuluz/ee/rest/client/mp/MicroprofileRestClientExtension.java
+++ b/src/main/java/com/kumuluz/ee/rest/client/mp/MicroprofileRestClientExtension.java
@@ -40,7 +40,6 @@ import java.util.logging.Logger;
         @EeComponentDependency(EeComponentType.CDI),
         @EeComponentDependency(EeComponentType.JAX_RS),
         @EeComponentDependency(EeComponentType.JSON_P),
-        @EeComponentDependency(EeComponentType.JSON_B)
 })
 public class MicroprofileRestClientExtension implements Extension {
 

--- a/src/main/java/com/kumuluz/ee/rest/client/mp/invoker/RestClientInvoker.java
+++ b/src/main/java/com/kumuluz/ee/rest/client/mp/invoker/RestClientInvoker.java
@@ -37,7 +37,6 @@ import javax.enterprise.inject.Instance;
 import javax.enterprise.inject.spi.CDI;
 import javax.json.JsonArray;
 import javax.json.JsonObject;
-import javax.json.bind.JsonbBuilder;
 import javax.ws.rs.*;
 import javax.ws.rs.client.*;
 import javax.ws.rs.core.*;
@@ -287,7 +286,6 @@ public class RestClientInvoker implements InvocationHandler {
         }
     }
 
-    @SuppressWarnings({"unchecked", "rawtypes"})
     private Object processResponse(Type returnType, Response response) {
         if (!void.class.equals(returnType)) {
             if (returnType.equals(Response.class)) {
@@ -295,12 +293,7 @@ public class RestClientInvoker implements InvocationHandler {
                 return response;
             } else {
                 // get user defined entity
-                if (returnType instanceof ParameterizedType) {
-                    String body = response.readEntity(String.class);
-                    return JsonbBuilder.create().fromJson(body, returnType);
-                } else {
-                    return response.readEntity((Class) returnType);
-                }
+                return response.readEntity(new GenericType<>(returnType));
             }
         }
         return null;


### PR DESCRIPTION
This makes rest-client behavior consistent with jax-rs behavior:

- If JSON-B dependency is not present, Jackson will be used for marshalling/unmarshalling
- If JSON-B dependency is present, JSON-B will be used for marshalling/unmarshalling