### PR TITLE
Make http client implementation configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,30 @@ kumuluzee:
 When using both configuration keys and fully qualified class names for the configuration the fully qualified class
 name configuration takes precedence.
 
+### Configuration of underlying http client
+
+Corresponding jetty javadoc for jetty can be found [here](https://www.eclipse.org/jetty/javadoc/9.4.35.v20201120/org/eclipse/jetty/client/HttpClient.html).
+
+Configuration for `http-url` native java connector is not yet possible due to limitations in Jersey. 
+
+```yaml
+kumuluzee:
+  rest-client:
+    http-client-connector: jetty # or http-url, java native http client
+    enable-ssl-hostname-verification: true
+    disable-jetty-www-auth: true
+    jetty:
+      address-resolution-timeout: 100 #in ms
+      connect-timeout: 100 # in ms
+      default-request-content-type: application/json
+      follow-redirects: true
+      idle-timeout: 30000 # in ms
+      max-redirects: 3
+      request-buffer-size: 4000 # in bytes, internal buffers only, not max size
+      read-buffer-size: 4000 # in bytes, internal buffers only, not max size
+      tcp-no-delay: false
+```
+
 ### Making asynchronous requests
 
 In order to make requests asynchronously the method in the API interface should return parameterized type


### PR DESCRIPTION
This partially addresses https://github.com/kumuluz/kumuluzee/issues/185
The original issue can be temporarily solved by switching to http-url connector.

Jetty has default max read buffer size of 2MB which is not configurable at HttpClient level but only at Request level which is too late for us. Request is built inside jersey jetty connector so in order to support >2MB payloads a jersey patch is needed. I will try to adress the issue with upstream to move forward. 
Additional problem is that http-url connector is not exposed by jersey (unlike jetty) to configure it in depth so that is the second issue I will try to adress upstream.

TODO: configure unit tests to run with http-url provider