### PR TITLE
Bump jersey version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.kumuluz.ee.rest-client</groupId>
     <artifactId>kumuluzee-rest-client</artifactId>
-    <version>1.5.0-SNAPSHOT</version>
+    <version>1.5.0-qplist</version>
 
     <name>KumuluzEE Microprofile Rest Client</name>
     <inceptionYear>2018</inceptionYear>
@@ -24,7 +24,7 @@
         <microprofile.rest-client.version>1.4.1</microprofile.rest-client.version>
         <microprofile.config.version>1.3</microprofile.config.version>
         <microprofile.fault-tolerance.version>1.1.4</microprofile.fault-tolerance.version>
-        <jersey-media.version>2.32</jersey-media.version>
+        <jersey-media.version>2.34</jersey-media.version>
 
         <kumuluzee.config.version>1.4.0</kumuluzee.config.version>
         <kumuluzee.rest.version>1.3.1</kumuluzee.rest.version>

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
         <microprofile.rest-client.version>1.4.1</microprofile.rest-client.version>
         <microprofile.config.version>1.3</microprofile.config.version>
         <microprofile.fault-tolerance.version>1.1.4</microprofile.fault-tolerance.version>
-        <jersey-media.version>2.28</jersey-media.version>
+        <jersey-media.version>2.32</jersey-media.version>
 
         <kumuluzee.config.version>1.4.0</kumuluzee.config.version>
         <kumuluzee.rest.version>1.3.1</kumuluzee.rest.version>


### PR DESCRIPTION
KumuluzEE Rest Client library fails with linkage error due to invalid dependency versions.

KumuluzEE 3.12.1 has Jersey 2.32 but Rest Client lags behind with 2.28.

This pull request bumps Jersey version to 2.32 and fixes that problem.